### PR TITLE
[Feature] - Creating common component between Login and Register page

### DIFF
--- a/src/assets/eye-close-solid.svg
+++ b/src/assets/eye-close-solid.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg width="inherit" height="inherit" viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg">
+  <g id="Layer_2" data-name="Layer 2">
+    <g id="invisible_box" data-name="invisible box">
+      <rect width="inherit" height="inherit" fill="currentColor"/>
+    </g>
+    <g id="icons_Q2" data-name="icons Q2">
+      <g>
+        <path d="M45.3,22.1C43.2,19.5,35.4,11,24,11a23.4,23.4,0,0,0-3.8.3L39.9,31.1a30.1,30.1,0,0,0,5.4-5.2A3,3,0,0,0,45.3,22.1Z"/>
+        <path d="M41.1,38.3,29.4,26.6A5.9,5.9,0,0,1,24,30a6,6,0,0,1-6-6,5.9,5.9,0,0,1,3.4-5.4L9.7,6.9A2,2,0,0,0,6.9,9.7l4.8,4.8a31.4,31.4,0,0,0-9,7.6,3,3,0,0,0,0,3.8C4.8,28.5,12.6,37,24,37a25.2,25.2,0,0,0,8.5-1.6l5.8,5.7a2,2,0,1,0,2.8-2.8Z"/>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/src/assets/eye-open.svg
+++ b/src/assets/eye-open.svg
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg version="1.1"
+	 id="svg2" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" sodipodi:docname="eye-open.svg" inkscape:version="0.48.4 r9939"
+	 xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"  width="inherit" height="inherit"
+	 viewBox="0 0 1200 1200" enable-background="new 0 0 1200 1200" xml:space="preserve"
+>
+<sodipodi:namedview  inkscape:cy="417.05123" inkscape:cx="455.50398" inkscape:zoom="0.37249375" showgrid="false" id="namedview30" guidetolerance="10" gridtolerance="10" objecttolerance="10" borderopacity="1" bordercolor="currentColor" pagecolor="currentColor" inkscape:current-layer="svg2" inkscape:window-maximized="1" inkscape:window-y="24" inkscape:window-height="inherit" inkscape:window-width="1535" inkscape:pageshadow="2" inkscape:pageopacity="0" inkscape:window-x="65">
+	</sodipodi:namedview>
+<path id="path6686" inkscape:connector-curvature="0" d="M779.843,599.925c0,95.331-80.664,172.612-180.169,172.612
+	c-99.504,0-180.168-77.281-180.168-172.612c0-95.332,80.664-172.612,180.168-172.612
+	C699.179,427.312,779.843,504.594,779.843,599.925z M600,240.521c-103.025,0.457-209.814,25.538-310.904,73.557
+	c-75.058,37.122-148.206,89.496-211.702,154.141C46.208,501.218,6.431,549,0,599.981c0.76,44.161,48.13,98.669,77.394,131.763
+	c59.543,62.106,130.786,113.018,211.702,154.179c94.271,45.751,198.616,72.092,310.904,73.557
+	c103.123-0.464,209.888-25.834,310.866-73.557c75.058-37.122,148.243-89.534,211.74-154.179
+	c31.185-32.999,70.962-80.782,77.394-131.763c-0.76-44.161-48.13-98.671-77.394-131.764
+	c-59.543-62.106-130.824-112.979-211.74-154.141C816.644,268.36,712.042,242.2,600,240.521z M599.924,329.769
+	c156.119,0,282.675,120.994,282.675,270.251c0,149.256-126.556,270.25-282.675,270.25S317.249,749.275,317.249,600.02
+	C317.249,450.763,443.805,329.769,599.924,329.769L599.924,329.769z"/>
+</svg>

--- a/src/components/ConnectionPages/ConnectionPagesContainer.tsx
+++ b/src/components/ConnectionPages/ConnectionPagesContainer.tsx
@@ -1,0 +1,9 @@
+import { IConnectionPages } from './IConnectionPages';
+
+export const ConnectionPagesContainer = ({ children }: IConnectionPages) => {
+  return (
+    <section className='w-full h-full flex flex-col gap-5 justify-center items-center'>
+      {children}
+    </section>
+  );
+};

--- a/src/components/ConnectionPages/ConnectionPagesTitle.tsx
+++ b/src/components/ConnectionPages/ConnectionPagesTitle.tsx
@@ -1,0 +1,9 @@
+import { IConnectionPages } from './IConnectionPages';
+
+export const ConnectionPagesTitle = ({ children }: IConnectionPages) => {
+  return (
+    <h2 className='font-alumini-sans text-5xl text-chocolate tracking-[4px]'>
+      {children}
+    </h2>
+  );
+};

--- a/src/components/ConnectionPages/IConnectionPages.ts
+++ b/src/components/ConnectionPages/IConnectionPages.ts
@@ -1,0 +1,3 @@
+import { ReactNode } from "react";
+
+export interface IConnectionPages { children: ReactNode }

--- a/src/components/PasswordField/IPasswordField.ts
+++ b/src/components/PasswordField/IPasswordField.ts
@@ -1,0 +1,3 @@
+import { InputHTMLAttributes } from "react";
+
+export interface IPasswordField extends InputHTMLAttributes<HTMLInputElement> {}

--- a/src/components/PasswordField/index.tsx
+++ b/src/components/PasswordField/index.tsx
@@ -1,0 +1,35 @@
+import { usePassword } from '@/hooks/usePassword';
+import { Label } from '@/components/Label';
+import { Input } from '../Input';
+import EyeOpenIcon from '@/assets/eye-open.svg';
+import EyeCloseIcon from '@/assets/eye-close-solid.svg';
+import { IPasswordField } from './IPasswordField';
+
+export const PasswordField = ({ ...props }: IPasswordField) => {
+  const {
+    showPassword,
+    passwordFieldType,
+    passwordIconButtonSupportText,
+    togglePasswordVisibility,
+  } = usePassword();
+
+  return (
+    <>
+      <Label htmlFor='password-field'>Senha</Label>
+
+      <div className='relative'>
+        <Input id='password-field' type={passwordFieldType} placeholder='****' {...props} />
+
+        <button
+          type='button'
+          onClick={togglePasswordVisibility}
+          className='w-5 fill-chocolate  absolute z-50 right-6 top-1/3'
+          aria-label={passwordIconButtonSupportText}
+          title={passwordIconButtonSupportText}
+        >
+          {showPassword ? <EyeCloseIcon /> : <EyeOpenIcon />}
+        </button>
+      </div>
+    </>
+  );
+};

--- a/src/components/ThirdPartyConnectionSection/IThirdPartyConnectionSection.ts
+++ b/src/components/ThirdPartyConnectionSection/IThirdPartyConnectionSection.ts
@@ -1,0 +1,5 @@
+export interface IThirdPartyConnectionSection {
+  text: string
+  googleSupportText: string
+  githubSupportText: string
+}

--- a/src/components/ThirdPartyConnectionSection/index.tsx
+++ b/src/components/ThirdPartyConnectionSection/index.tsx
@@ -1,0 +1,36 @@
+import GoogleLogo from '@/assets/google-logo.svg';
+import GithubLogo from '@/assets/github-logo.svg';
+import { Typography } from '@/components/Typography';
+import { IThirdPartyConnectionSection } from './IThirdPartyConnectionSection';
+
+export const ThirdPartyConnectionSection = ({
+  text,
+  googleSupportText,
+  githubSupportText,
+}: IThirdPartyConnectionSection) => {
+  return (
+    <div className='flex flex-col gap-2 items-center'>
+      <Typography size='sm' className='font-medium'>
+        {text}
+      </Typography>
+
+      <div className='flex gap-4'>
+        <button
+          type='button'
+          className='fill-chocolate w-6'
+          title={googleSupportText}
+        >
+          <GoogleLogo />
+        </button>
+
+        <button
+          type='button'
+          className='fill-chocolate w-7'
+          title={githubSupportText}
+        >
+          <GithubLogo />
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/src/hooks/usePassword.ts
+++ b/src/hooks/usePassword.ts
@@ -1,0 +1,18 @@
+import { useState } from "react";
+
+export function usePassword() {
+    const [showPassword, setShowPassword] = useState(false);
+    const passwordFieldType = showPassword ? 'text' : 'password';
+    const passwordIconButtonSupportText = showPassword
+    ? 'Ocultar senha'
+    : 'Exibir senha';
+
+    const togglePasswordVisibility = () => setShowPassword((prev) => !prev)
+
+    return {
+        showPassword,
+        passwordFieldType,
+        passwordIconButtonSupportText,
+        togglePasswordVisibility
+    }
+}


### PR DESCRIPTION
Made changes: 
- Create common components between pages Login and Register, like ConnectionPages, ThirdPartyConnectionSection, and, PasswordField.
![image](https://github.com/user-attachments/assets/1612386d-3ea0-4504-9538-ce035931a083)
![image](https://github.com/user-attachments/assets/f3f304f0-5b40-4d6b-a132-2e49cde6ff29)
![image](https://github.com/user-attachments/assets/ef853eeb-f64c-4736-a5f5-f3cb3071e188)

- Add new icons

- Create a custom hook usePassword to handle the visibility of the password in the password field